### PR TITLE
[6] - Fixed a case where the item was not being track during an update

### DIFF
--- a/Timelapse.CLI/Application/ApplicationServices/ItemService.cs
+++ b/Timelapse.CLI/Application/ApplicationServices/ItemService.cs
@@ -21,6 +21,7 @@ namespace Timelapse.CLI.Application.ApplicationServices
         public async Task<Item?> Get(string name, CancellationToken ct)
         {
             return await _context.Items
+                .Include(w => w.Periods)
                 .Where(w => w.Name == name)
                 .FirstOrDefaultAsync(ct);
         }

--- a/Timelapse.CLI/Commands/StartCommand.cs
+++ b/Timelapse.CLI/Commands/StartCommand.cs
@@ -28,7 +28,7 @@ namespace Timelapse.CLI.Commands
 
         public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
         {
-            var item = await _itemService.GetAsNoTracking(settings.Name, default);
+            var item = await _itemService.Get(settings.Name, default);
 
             if (item is null)
             {


### PR DESCRIPTION
# Fixed

* Fixed a small case that made the item show as not running because of how the changes were being tracked [#6]