### PR TITLE
Added the option to start and stop tracking with a given date

### DIFF
--- a/Timelapse.CLI/Application/ApplicationServices/Interfaces/IItemService.cs
+++ b/Timelapse.CLI/Application/ApplicationServices/Interfaces/IItemService.cs
@@ -15,5 +15,6 @@ namespace Timelapse.CLI.Application.ApplicationServices.Interfaces
         Task<Item> Update(Item item, CancellationToken ct);
         ValueTask<bool> Exists(string name, CancellationToken ct);
         ValueTask<bool> IsRunning(string name, CancellationToken ct);
+        ValueTask<bool> IsAnyRunning(CancellationToken ct);
     }
 }

--- a/Timelapse.CLI/Commands/StartCommand.cs
+++ b/Timelapse.CLI/Commands/StartCommand.cs
@@ -21,6 +21,10 @@ namespace Timelapse.CLI.Commands
             [DefaultValue("")]
             public string Anchor { get; init; } = default!;
 
+            [CommandOption("-d|--date")]
+            [DefaultValue("")]
+            public string Date { get; init; } = default!;
+
         }
 
         private readonly IItemService _itemService = itemService;
@@ -28,6 +32,31 @@ namespace Timelapse.CLI.Commands
 
         public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
         {
+            if (await _itemService.IsAnyRunning(default))
+            {
+                var lastRunningPeriod = (await _periodService.GetLastRunningPeriod(default))!;
+
+                ErrorView.Show($"The item \"{lastRunningPeriod.Item.Name}\" is already running. " +
+                    "Please stop the running item first to start another one");
+                return 0;
+            }
+
+            var startedAt = DateTime.Now;
+            if (!string.IsNullOrWhiteSpace(settings.Date))
+            {
+                if (!DateTime.TryParse(settings.Date, out startedAt))
+                {
+                    ErrorView.Show("Could not parse the given date");
+                    return -1;
+                }
+
+                if (startedAt.ToUniversalTime() > DateTime.UtcNow)
+                {
+                    ErrorView.Show("You cannot start an item in a future date");
+                    return -1;
+                }
+            }
+
             var item = await _itemService.Get(settings.Name, default);
 
             if (item is null)
@@ -43,16 +72,16 @@ namespace Timelapse.CLI.Commands
             }
             else
             {
-                if (await _itemService.IsRunning(settings.Name, default))
+                if (startedAt.ToUniversalTime() <= item.Periods.Last().StoppedAt)
                 {
-                    TableView.Show(item);
+                    ErrorView.Show("You cannot start an item with a date older then the last tracking period");
                     return 0;
                 }
             }
 
             var period = new Period
             {
-                StartedAt = DateTime.UtcNow,
+                StartedAt = startedAt.ToUniversalTime(),
                 ItemId = item.ItemId,
             };
             await _periodService.Add(period, default);

--- a/Timelapse.CLI/Commands/StopCommand.cs
+++ b/Timelapse.CLI/Commands/StopCommand.cs
@@ -1,5 +1,7 @@
 ﻿using Spectre.Console.Cli;
+using System.ComponentModel;
 using Timelapse.CLI.Application.ApplicationServices.Interfaces;
+using Timelapse.CLI.Entities;
 using Timelapse.CLI.Views;
 
 namespace Timelapse.CLI.Commands
@@ -13,23 +15,48 @@ namespace Timelapse.CLI.Commands
         {
             [CommandArgument(0, "[Commentary]")]
             public string? Commentary { get; set; } = default!;
+
+            [CommandOption("-d|--date")]
+            [DefaultValue("")]
+            public string Date { get; init; } = default!;
         }
 
         public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
         {
             var period = await _periodService.GetLastRunningPeriod(default);
 
-            if(period is null)
+            if (period is null)
             {
                 return 0;
             }
 
-            period.StoppedAt = DateTime.UtcNow;
+            var stopedAt = DateTime.Now;
+
+            if (!string.IsNullOrWhiteSpace(settings.Date))
+            {
+                if (!DateTime.TryParse(settings.Date, out stopedAt))
+                {
+                    throw new FormatException("Could not parse the given date");
+                }
+
+                if (stopedAt.ToUniversalTime() > DateTime.UtcNow)
+                {
+                    ErrorView.Show("You cannot stop an item in a future date");
+                    return -1;
+                }
+            }
+
+            if (stopedAt.ToUniversalTime() <= period.StartedAt)
+            {
+                ErrorView.Show("You cannot stop an item with a date older then the start tracking period");
+                return 0;
+            }
+
+            period.StoppedAt = stopedAt.ToUniversalTime();
 
             period = await _periodService.Update(period, default);
 
             TableView.Show(period.Item);
-
             return 0;
         }
     }

--- a/Timelapse.CLI/Program.cs
+++ b/Timelapse.CLI/Program.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Spectre.Console.Cli;
 using Timelapse.CLI.Application.ApplicationServices;

--- a/Timelapse.CLI/Properties/launchSettings.json
+++ b/Timelapse.CLI/Properties/launchSettings.json
@@ -14,7 +14,7 @@
     },
     "Stop": {
       "commandName": "Project",
-      "commandLineArgs": "stop \"lunch break\""
+      "commandLineArgs": "stop \"lunch break\" -d 22:30"
     }
   }
 }

--- a/Timelapse.CLI/Views/ErrorView.cs
+++ b/Timelapse.CLI/Views/ErrorView.cs
@@ -1,0 +1,12 @@
+﻿using Spectre.Console;
+
+namespace Timelapse.CLI.Views
+{
+    internal static class ErrorView
+    {
+        public static void Show(string message)
+        {
+            AnsiConsole.MarkupLine($"[Red]Error:[/] {message}");
+        }
+    }
+}

--- a/Timelapse.CLI/Views/TableView.cs
+++ b/Timelapse.CLI/Views/TableView.cs
@@ -17,20 +17,27 @@ namespace Timelapse.CLI.Views
                 "Duration",
                 "Comment");
 
-            foreach (var result in periods.Select((value, i) => new { Index = i, Value = value }))
+            for (var i = 0; i < periods.Count(); i++)
             {
+                var period = periods.ElementAt(i);
+
                 table.AddRow(
-                    result.Index.ToString(),
-                    result.Value.Item.HasAnchor() ? 
-                        $"[link={result.Value.Item.Anchor}]{result.Value.Item.Name}[/]" 
-                        : result.Value.Item.Name,
-                    result.Value.StartedAt.ToLocalTime().ToString("g"),
-                    result.Value.StoppedAt?.ToLocalTime().ToString("g") ?? "-",
-                    result.Value.GetDuration().ToString(@"hh\:mm\:ss"),
-                    result.Value.Commentary ?? string.Empty);
+                    (i + 1).ToString(),
+                    period.Item.HasAnchor() ?
+                        $"[link={period.Item.Anchor}]{period.Item.Name}[/]"
+                        : period.Item.Name,
+                    period.StartedAt.ToLocalTime().ToString("g"),
+                    period.StoppedAt?.ToLocalTime().ToString("g") ?? "-",
+                    period.GetDuration().ToString(@"hh\:mm\:ss"),
+                    period.Commentary ?? string.Empty);
             }
 
             AnsiConsole.Write(table);
+        }
+
+        public static void Show(Period period)
+        {
+            Show([period]);
         }
 
         public static void Show(IEnumerable<Item> items)
@@ -43,15 +50,17 @@ namespace Timelapse.CLI.Views
                 "Status",
                 "Duration");
 
-            foreach (var result in items.Select((value, i) => new { Index = i, Value = value }))
+            for (var i = 0; i < items.Count(); i++)
             {
+                var item = items.ElementAt(i);
+
                 table.AddRow(
-                    result.Index.ToString(),
-                    result.Value.HasAnchor() ? 
-                        $"[link={result.Value.Anchor}]{result.Value.Name}[/]" 
-                        : result.Value.Name,
-                    result.Value.IsRunning() ? "Running" : "Stopped",
-                    result.Value.GetTotalDuration().ToString(@"hh\:mm\:ss")
+                    (i + 1).ToString(),
+                    item.HasAnchor() ?
+                        $"[link={item.Anchor}]{item.Name}[/]"
+                        : item.Name,
+                    item.IsRunning() ? "Running" : "Stopped",
+                    item.GetTotalDuration().ToString(@"hh\:mm\:ss")
                 );
             }
 


### PR DESCRIPTION
# Added

* Added the option to start and stop the tracking when the given date is between a certain period of time. If it's starting, the given date must be between the last stopped period and the actual time, if it's stopping the given date should be between the starting time of the period and the actual time. [fix #14]
* Added a verification to guarantee the tracking of a single item at a time.
* Added an Error view to show error messages without dealing with exceptions.