### PR TITLE
Items now can be listed with a certain period of time informed

### DIFF
--- a/Timelapse.CLI/Commands/ListCommand.cs
+++ b/Timelapse.CLI/Commands/ListCommand.cs
@@ -10,7 +10,7 @@ namespace Timelapse.CLI.Commands
         {
             [CommandOption("-s|--start")]
             public string? StartPeriod { get; set; }
-            
+
             [CommandOption("-e|--end")]
             public string? EndPeriod { get; set; }
         }
@@ -27,7 +27,7 @@ namespace Timelapse.CLI.Commands
                     return 0;
                 }
                 else
-                { 
+                {
                     ErrorView.Show("You have to inform the Starting Period when you already informed the End Period");
                     return -1;
                 }
@@ -48,7 +48,7 @@ namespace Timelapse.CLI.Commands
                 }
             }
 
-            if(endPeriod < startPeriod)
+            if (endPeriod < startPeriod)
             {
                 ErrorView.Show("The End Period cannot be older than the start period");
                 return -1;

--- a/Timelapse.CLI/Commands/ListCommand.cs
+++ b/Timelapse.CLI/Commands/ListCommand.cs
@@ -8,15 +8,54 @@ namespace Timelapse.CLI.Commands
     {
         public class Settings : CommandSettings
         {
-            [CommandArgument(0, "[Running]")]
-            public bool Running { get; set; } = default!;
+            [CommandOption("-s|--start")]
+            public string? StartPeriod { get; set; }
+            
+            [CommandOption("-e|--end")]
+            public string? EndPeriod { get; set; }
         }
 
         private readonly IPeriodService _periodService = periodService;
 
         public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
         {
-            var periods = await _periodService.GetAsNoTracking(5, default);
+            if (string.IsNullOrWhiteSpace(settings.StartPeriod))
+            {
+                if (string.IsNullOrWhiteSpace(settings.EndPeriod))
+                {
+                    TableView.Show(await _periodService.GetAsNoTracking(5, default));
+                    return 0;
+                }
+                else
+                { 
+                    ErrorView.Show("You have to inform the Starting Period when you already informed the End Period");
+                    return -1;
+                }
+
+            }
+
+            if (!DateTime.TryParse(settings.StartPeriod, out var startPeriod))
+                ErrorView.Show("Could not parse the given start period");
+
+            var endPeriod = startPeriod.AddDays(1);
+
+            if (!string.IsNullOrWhiteSpace(settings.EndPeriod))
+            {
+                if (!DateTime.TryParse(settings.EndPeriod, out endPeriod))
+                {
+                    ErrorView.Show("Could not parse the given end period");
+                    return -1;
+                }
+            }
+
+            if(endPeriod < startPeriod)
+            {
+                ErrorView.Show("The End Period cannot be older than the start period");
+                return -1;
+            }
+
+            var periods = await _periodService
+                .GetAsNoTracking(w => w.StartedAt >= startPeriod && w.StoppedAt <= endPeriod, default);
 
             TableView.Show(periods);
             return 0;

--- a/Timelapse.CLI/Commands/StopCommand.cs
+++ b/Timelapse.CLI/Commands/StopCommand.cs
@@ -1,7 +1,6 @@
 ﻿using Spectre.Console.Cli;
 using System.ComponentModel;
 using Timelapse.CLI.Application.ApplicationServices.Interfaces;
-using Timelapse.CLI.Entities;
 using Timelapse.CLI.Views;
 
 namespace Timelapse.CLI.Commands

--- a/Timelapse.CLI/Properties/launchSettings.json
+++ b/Timelapse.CLI/Properties/launchSettings.json
@@ -10,7 +10,7 @@
     },
     "List": {
       "commandName": "Project",
-      "commandLineArgs": "list"
+      "commandLineArgs": "list -s 01/01/2022 -e 01/01/2021\r\n"
     },
     "Stop": {
       "commandName": "Project",

--- a/Timelapse.CLI/Timelapse.CLI.csproj
+++ b/Timelapse.CLI/Timelapse.CLI.csproj
@@ -4,7 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+	<IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
+	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Timelapse.CLI/Views/TableView.cs
+++ b/Timelapse.CLI/Views/TableView.cs
@@ -20,6 +20,7 @@ namespace Timelapse.CLI.Views
             for (var i = 0; i < periods.Count(); i++)
             {
                 var period = periods.ElementAt(i);
+                var duration = period.GetDuration();
 
                 table.AddRow(
                     (i + 1).ToString(),
@@ -28,7 +29,8 @@ namespace Timelapse.CLI.Views
                         : period.Item.Name,
                     period.StartedAt.ToLocalTime().ToString("g"),
                     period.StoppedAt?.ToLocalTime().ToString("g") ?? "-",
-                    period.GetDuration().ToString(@"hh\:mm\:ss"),
+                    duration.ToString(duration.Days > 0 ?
+                        @"%d'd 'hh\:mm" : @"hh\:mm\:ss"),
                     period.Commentary ?? string.Empty);
             }
 
@@ -48,19 +50,24 @@ namespace Timelapse.CLI.Views
                 "#",
                 "Name",
                 "Status",
-                "Duration");
+                "Total Duration");
 
             for (var i = 0; i < items.Count(); i++)
             {
                 var item = items.ElementAt(i);
 
+                var totalDuration = item.GetTotalDuration();
+
                 table.AddRow(
                     (i + 1).ToString(),
+
                     item.HasAnchor() ?
                         $"[link={item.Anchor}]{item.Name}[/]"
                         : item.Name,
+
                     item.IsRunning() ? "Running" : "Stopped",
-                    item.GetTotalDuration().ToString(@"hh\:mm\:ss")
+                    totalDuration.ToString(totalDuration.Days > 0 ? 
+                        @"%d'd 'hh\:mm" : @"hh\:mm\:ss")
                 );
             }
 


### PR DESCRIPTION
# Added 
* Added parameters to inform a start and end period to list items in between that period of time [fix #20]

# Changed
* The grid view now shows days in the duration column
* Changed the list view of the items from "Duration" to "Total duration" to avoid confusion